### PR TITLE
fix: corrected add todo button disabled logic and typo

### DIFF
--- a/learns-app-content/assignments/week-06.md
+++ b/learns-app-content/assignments/week-06.md
@@ -145,7 +145,7 @@ At this point, when you click on the todo in the list, it will toggle between be
 
 - Create a new state variable, `workingTitle` and its associated state update function. Set the `initialValue` to `todo.title`
 - Create a `handleCancel` event helper that:
-  - resets the `workingTitle` to `todo.tile`
+  - resets the `workingTitle` to `todo.title`
   - sets `isEditing` state value to `false`
   - there is no need to include an argument
 - Add a button below the `TextInputWithLabel` component:

--- a/learns-app-content/assignments/week-07.md
+++ b/learns-app-content/assignments/week-07.md
@@ -274,7 +274,7 @@ In App:
 It should now look like:
 
 ```jsx
-<button disabled={isButtonDisabled}>
+<button disabled={workingTodoTitle.trim() === ''}>
     {isSaving ? 'Saving...' : 'Add Todo'}
 </button>
 ```


### PR DESCRIPTION
## Brief Summary of Proposed Changes
Correct disabled logic for the add todo button

## Rationale for Proposed Changes
Correct error in assignment code instruction

## Link to any Related Issues
Relates to issue https://github.com/Code-the-Dream-School/react-curriculum-v3/issues/158

## Confirm

- [x] All text follows the [GitHub Flavored Markdown Spec](https://github.github.com/gfm/) and is organized using the correct heading levels.
- [x] All new pictures or media include descriptive alt text.
- [x] Code blocks have been formatted and given the appropriate language label.
